### PR TITLE
updating analog dependency to 1.0.2-stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.0",
         "guzzle/guzzle": "~3.1",
-        "analog/analog": "1.0.1-stable"
+        "analog/analog": "1.0.2-stable"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
analog 1.0.2 addresses the following issue:
https://github.com/jbroadway/analog/pull/12

Will you also need to update your package on packagist or will it "Just work" ?
