### PR TITLE
Treating raw queries as-is

### DIFF
--- a/src/Sherlock/requests/SearchRequest.php
+++ b/src/Sherlock/requests/SearchRequest.php
@@ -236,6 +236,9 @@ class SearchRequest extends Request
     {
         $finalQuery = array();
 
+		// If the query is a raw one, use query as-is
+		if($this->params['query'] instanceof \Sherlock\components\queries\Raw)
+			return $this->params['query']->toJSON();
 
         if (isset($this->params['query']) && $this->params['query'] instanceof \Sherlock\components\QueryInterface)
         	$finalQuery['query'] = $this->params['query']->toArray();


### PR DESCRIPTION
Raw queries are now treated as-is in the form they came in. There is no
additional wrapping around it, limiting its scope.
