### PR TITLE
The $value parameter wasn't used which results in an empty query

### DIFF
--- a/src/Sherlock/components/queries/Bool.php
+++ b/src/Sherlock/components/queries/Bool.php
@@ -32,7 +32,7 @@ class Bool extends \Sherlock\components\BaseComponent implements \Sherlock\compo
 
     public function must($value)
     {
-        $args = func_get_args();
+        $args = func_get_args($value);
         if (count($args) == 1)
             $args = $args[0];
 
@@ -46,7 +46,7 @@ class Bool extends \Sherlock\components\BaseComponent implements \Sherlock\compo
 
     public function must_not($value)
     {
-        $args = func_get_args();
+        $args = func_get_args($value);
         if (count($args) == 1)
             $args = $args[0];
 
@@ -60,7 +60,7 @@ class Bool extends \Sherlock\components\BaseComponent implements \Sherlock\compo
 
     public function should($value)
     {
-        $args = func_get_args();
+        $args = func_get_args($value);
         if (count($args) == 1)
             $args = $args[0];
 


### PR DESCRIPTION
In components/queries/Book the $value parameter for the must(), should() and must_not() methods were unused, which resulted in empty queries.
