### PR TITLE
Corrected quickstart & documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Features
 
 Resources
 ---------------
- - Read the [Quickstart Guide](http://sherlockphp.com/quickstart.html)
- - Read the [Full Documentation](http://sherlockphp.com/documentation.html)
+ - Read the [Quickstart Guide](http://sherlockphp.com/quickstart/)
+ - Read the [Full Documentation](http://sherlockphp.com/documentation/)
 
 Installation via Composer
 -------------------------


### PR DESCRIPTION
Quickstart & documentation links pointed to a missing page (404).
Corrected them according to site navigation
