### PR TITLE
$this->params['filter'] needs to be converted to an array.

### DIFF
--- a/src/Sherlock/components/queries/FilteredQuery.php
+++ b/src/Sherlock/components/queries/FilteredQuery.php
@@ -29,7 +29,7 @@ class FilteredQuery extends \Sherlock\components\BaseComponent implements \Sherl
   'filtered' =>
   array (
     'query' => $this->params["query"]->toArray(),
-    'filter' => $this->params["filter"],
+    'filter' => $this->params["filter"]->toArray(),
   ),
 );
 


### PR DESCRIPTION
### Summary

When using FilteredQuery, `$request->toJSON()` is missing filter data. In the example below, the output looks like this:

`{"filtered":{"query":{"match_all":{"boost":1}},"filter":{}}}`

The problem is that in [`FilteredQuery::toArray()`](https://github.com/polyfractal/sherlock/blob/master/src/Sherlock/components/queries/FilteredQuery.php#L32) we are not converting `$this->params['filter']` to an array, so when converting to JSON later, the Filter object is empty. Whoops!

This patch makes sure that it also gets converted to an array, returning the proper JSON of:

`{"filtered":{"query":{"match_all":{"boost":1}},"filter":{"term":{"foo":"bar","_cache":true}}}`
### Test

Run the following code in master:

```
$filter = Sherlock\Sherlock::filterBuilder()
                            ->Term()
                                ->field('foo')
                                ->term('bar

$query = Sherlock\Sherlock::queryBuilder()
                        ->matchAll();

$search = Sherlock\Sherlock::queryBuilder()
                    ->filteredQuery()
                        ->query($query)
                        ->filter($filter);

//Set the index, type and from/to parameters of the request.
$request->index("tweeter")
                ->type("tweet")
                ->query($search);

echo $request->toJSON();
```

Note that the request JSON is missing filter data. 

Next, run the same code in this branch, and note that the filter data is present.
