### PR TITLE
Readme fix. New query type: Text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The library interface is still under flux...this section will be updated once _S
             ->type("tweet")
             ->from(0)
             ->to(10)
-            ->query(Sherlock::query()->Term()->field("message")
+            ->query(Sherlock::queryBuilder()->Term()->field("message")
                                               ->term("ElasticSearch"));
 
    //Execute the search and return results
@@ -102,17 +102,17 @@ The library interface is still under flux...this section will be updated once _S
 
    //Let's try a more advanced query now.
    //Each section is it's own variable to help show how everything fits together
-   $must = Sherlock::query()->Term()->field("message")
+   $must = Sherlock::queryBuilder()->Term()->field("message")
                                      ->term("ElasticSearch");
 
-   $should = Sherlock::query()->Match()->field("author")
+   $should = Sherlock::queryBuilder()->Match()->field("author")
                                         ->query("Zachary Tong")
                                         ->boost(2.5);
 
-   $must_not = Sherlock::query()->Term()->field("message")
+   $must_not = Sherlock::queryBuilder()->Term()->field("message")
                                            ->term("Solr");
 
-   $bool = Sherlock::query()->Bool->must($must)
+   $bool = Sherlock::queryBuilder()->Bool()->must($must)
                                    ->should($should)
                                    ->must_not($must_not);
    $request->query($bool);
@@ -129,7 +129,7 @@ Not a fan of ORM style construction?  Don't worry, _Sherlock_ supports "raw" ass
     //We can compose queries using hashmaps instead of the ORM.
     $manualData = array("field" => "field1", "term" => "town");
 
-    $request->query(Sherlock::query()->Term($manualData));
+    $request->query(Sherlock::queryBuilder()->Term($manualData));
 
 ```
 
@@ -141,7 +141,7 @@ Need to consume and use raw JSON?  No problem
     //We can compose queries using hashmaps instead of the ORM.
     $json = '{ "term" : { "field1" : "town" } }';
 
-    $request->query(Sherlock::query()->Raw($json));
+    $request->query(Sherlock::queryBuilder()->Raw($json));
 
 ```
 

--- a/src/Sherlock/components/queries/Text.php
+++ b/src/Sherlock/components/queries/Text.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * User: Ilia Shakitko
+ * Date: 2013-05-16
+ * Time: 12:00 PM
+ * @package Sherlock\components\queries
+ */
+namespace Sherlock\components\queries;
+
+use Sherlock\components;
+
+/**
+ * Class descibes 'text' type of query
+ *
+ * @method \Sherlock\components\queries\Text field() field(\string $value)
+ * @method \Sherlock\components\queries\Text text() text(\string $value)
+ */
+class Text extends \Sherlock\components\BaseComponent implements \Sherlock\components\QueryInterface
+{
+    /**
+     * Class constructor
+     *
+     * @param string $hashMap Hash map
+     */
+    public function __construct($hashMap = null)
+    {
+
+        parent::__construct($hashMap);
+    }
+
+    /**
+     * Method makes an array for using it when composing a request
+     *
+     * @see \Sherlock\components\QueryInterface::toArray()
+     *
+     * @return array Array with 'text' query type
+     */
+    public function toArray()
+    {
+        $ret = array (
+                'text' => array (
+                            $this->params["field"] => $this->params["text"]
+                          ),
+               );
+
+        return $ret;
+    }
+
+}


### PR DESCRIPTION
README.md was fixed with a correct examples. Bool -> Bool(), Sherlock::query() -> Sherlock::queryBuilder()

New query type: Text. 
