### PR TITLE
Implement Fields parameter of search query. Closes #19.

### DIFF
--- a/src/Sherlock/requests/SearchRequest.php
+++ b/src/Sherlock/requests/SearchRequest.php
@@ -135,6 +135,19 @@ class SearchRequest extends Request
     }
 
     /**
+     * Sets the fields that will be returned
+     * 
+     * @param $fields
+     * @return SearchRequest
+     */
+    public function fields($fields)
+    {
+        $this->params['fields'] = $fields;
+
+        return $this;
+    }
+
+    /**
      * Sets the filter that will be executed
      *
      * @param $filter
@@ -254,6 +267,10 @@ class SearchRequest extends Request
     {
         $finalQuery = array();
 
+        if (isset($this->params['fields'])) {
+            $finalQuery['fields'] = $this->params['fields'];
+        }
+        
         if (isset($this->params['query']) && $this->params['query'] instanceof components\QueryInterface) {
             $finalQuery['query'] = $this->params['query']->toArray();
         }


### PR DESCRIPTION
### Summary

Implement Fields parameter of search query.
### Test / Example

```
$sherlock = new Sherlock\Sherlock;
$request = $sherlock->search();

$query = Sherlock\Sherlock::queryBuilder()->matchAll();

$request->index('foo')
              ->type('bar')
              ->fields(array('id', 'name', 'created_on'))
              ->query($query);
```
