### PR TITLE
Added a DocumentMissingException

### DIFF
--- a/src/Sherlock/common/exceptions/DocumentMissingException.php
+++ b/src/Sherlock/common/exceptions/DocumentMissingException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sherlock\common\exceptions;
+
+/**
+ * Class DocumentMissingException
+ * @package Sherlock\common\exceptions
+ */
+class DocumentMissingException extends ClientErrorResponseException
+{
+}

--- a/src/Sherlock/responses/Response.php
+++ b/src/Sherlock/responses/Response.php
@@ -63,23 +63,27 @@ class Response
 
 
     /**
+     * @throws \Sherlock\common\exceptions\DocumentMissingException
      * @throws \Sherlock\common\exceptions\IndexAlreadyExistsException
      * @throws \Sherlock\common\exceptions\ClientErrorResponseException
      * @throws \Sherlock\common\exceptions\IndexMissingException
      */
     private function process4xx()
     {
-        $error = $this->responseData['error'];
-        Analog::error($error);
-
-        if (strpos($error, "IndexMissingException") !== false) {
-            throw new exceptions\IndexMissingException($error);
-        } elseif (strpos($error, "IndexAlreadyExistsException") !== false) {
-            throw new exceptions\IndexAlreadyExistsException($error);
+        if ($this->responseData['found'] == false) {
+            throw new exceptions\DocumentMissingException("Document is missing from the index");
         } else {
-            throw new exceptions\ClientErrorResponseException($error);
-        }
+            $error = $this->responseData['error'];
+            Analog::error($error);
 
+            if (strpos($error, "IndexMissingException") !== false) {
+                throw new exceptions\IndexMissingException($error);
+            } elseif (strpos($error, "IndexAlreadyExistsException") !== false) {
+                throw new exceptions\IndexAlreadyExistsException($error);
+            } else {
+                throw new exceptions\ClientErrorResponseException($error);
+            }
+        }
     }
 
 


### PR DESCRIPTION
When trying to delete a document that is not present in the index, the process4xx() method in responses/Response throws an error "undefined index: error" when trying to retrieve the error from the responseData.

I created a DocumentMissingException which will be thrown in the process4xx() method when the responseData['found'] is false. This prevents the above error and allows us to catch the exception and handle it gracefully.
