### PR TITLE
Boolquery issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ src/sherlock.log
 Icon?
 ehthumbs.db
 Thumbs.db
+*.sublime-*

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The library interface is still under flux...this section will be updated once _S
 
 ```php
    require 'vendor/autoload.php';
+	use Sherlock\Sherlock;
 
    //The Sherlock object manages cluster state, builds queries, etc
    $sherlock = new Sherlock();
@@ -82,7 +83,7 @@ The library interface is still under flux...this section will be updated once _S
             ->type("tweet")
             ->from(0)
             ->to(10);
-            ->query(Sherlock::query()->Term()->field("message")
+            ->query(Sherlock::queryBuilder()->Term()->field("message")
                                               ->term("ElasticSearch"));
 
    //Execute the search and return results
@@ -100,17 +101,17 @@ The library interface is still under flux...this section will be updated once _S
 
    //Let's try a more advanced query now.
    //Each section is it's own variable to help show how everything fits together
-   $must = Sherlock::query()->Term()->field("message")
+   $must = Sherlock::queryBuilder()->Term()->field("message")
                                      ->term("ElasticSearch");
 
-   $should = Sherlock::query()->Match()->field("author")
+   $should = Sherlock::queryBuilder()->Match()->field("author")
                                         ->query("Zachary Tong")
                                         ->boost(2.5);
 
-   $must_not = Sherlock::query()->Term()->field("message")
+   $must_not = Sherlock::queryBuilder()->Term()->field("message")
                                            ->term("Solr");
 
-   $bool = Sherlock::query()->Bool->must($must)
+   $bool = Sherlock::queryBuilder()->Bool->must($must)
                                    ->should($should)
                                    ->must_not($must_not);
    $request->query($bool);
@@ -127,7 +128,7 @@ Not a fan of ORM style construction?  Don't worry, _Sherlock_ supports "raw" ass
     //We can compose queries using hashmaps instead of the ORM.
     $manualData = array("field" => "field1", "term" => "town");
 
-    $request->query(Sherlock::query()->Term($manualData));
+    $request->query(Sherlock::queryBuilder()->Term($manualData));
 
 ```
 
@@ -139,7 +140,7 @@ Need to consume and use raw JSON?  No problem
     //We can compose queries using hashmaps instead of the ORM.
     $json = '{ "term" : { "field1" : "town" } }';
 
-    $request->query(Sherlock::query()->Raw($json));
+    $request->query(Sherlock::queryBuilder()->Raw($json));
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ E.g. if you'd like to use a _fuzzy like this (flt)_ query, you can build your qu
     $sherlock->addNode('localhost', 9200);
     $request = $sherlock->search();
 
-	$request->index('jdbc')
-			->type('jdbc')
+	$request->index('test')
+			->type('tweet')
 			->query(Sherlock::queryBuilder()
 				->FuzzyLikeThis()
 				->fields( array('description', 'tags', 'name') )
@@ -140,6 +140,24 @@ E.g. if you'd like to use a _fuzzy like this (flt)_ query, you can build your qu
 
 	$response = $request->execute();
 ```
+
+Filters
+-------
+Building filters is identical to building queries, but requires the use of _filterBuilder()_ instead of _queryBuilder()_.
+Again, a simple example would be:
+
+```php
+    $request->index('test')
+		->type('tweet')
+		->filter(Sherlock::filterBuilder()
+			->Term()
+			->field($type)
+			->term($value)
+		);
+	
+	$response = $request->execute();
+```
+
 
 
 Non-ORM style

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Other types of queries
 You can use sherlock with every type of query listed in the elasticsearch docs.
 E.g. if you'd like to use a _fuzzy like this (flt)_ query, you can build your query like this:
 
-	php
+```php
 	$sherlock = new Sherlock();
     $sherlock->addNode('localhost', 9200);
     $request = $sherlock->search();
@@ -140,11 +140,15 @@ E.g. if you'd like to use a _fuzzy like this (flt)_ query, you can build your qu
 			);
 
 	$response = $request->execute();
-
-
 ```
 
+
+Non-ORM style
+-------------
+
+
 Not a fan of ORM style construction?  Don't worry, _Sherlock_ supports "raw" associative arrays
+
 ```php
     //Build a new search request
     $request = $sherlock->search();

--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ Again, a simple example would be:
 	$response = $request->execute();
 ```
 
-
-
 Non-ORM style
 -------------
 Not a fan of ORM style construction?  Don't worry, _Sherlock_ supports "raw" associative arrays

--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ The library interface is still under flux...this section will be updated once _S
 
 Other types of queries
 ----------------------
-
-You can use sherlock with every type of query listed in the elasticsearch docs.
+You can use _Sherlock_ with every type of query listed in the elasticsearch docs.
 E.g. if you'd like to use a _fuzzy like this (flt)_ query, you can build your query like this:
 
 ```php
@@ -145,8 +144,6 @@ E.g. if you'd like to use a _fuzzy like this (flt)_ query, you can build your qu
 
 Non-ORM style
 -------------
-
-
 Not a fan of ORM style construction?  Don't worry, _Sherlock_ supports "raw" associative arrays
 
 ```php
@@ -174,7 +171,8 @@ Need to consume and use raw JSON?  No problem
 
 (There will be a RawQuery method soon, that lets you construct entirely arbitrary queries with arrays or JSON)
 
-For more examples check out the (Quickstart Guide)[http://sherlockphp.com/quickstart.html]
+For more examples check out the [Quickstart Guide](http://sherlockphp.com/quickstart.html)
+
 
 Philosophy
 ----------

--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ The library interface is still under flux...this section will be updated once _S
    $request->query($bool);
    $request->execute();
 
+```
+
+You can use sherlock with every type of query listed in the elasticsearch docs.
+E.g. if you'd like to use a _fuzzy like this (flt)_ query, you can build your query like this:
+	php
+	$sherlock = new Sherlock();
+    $sherlock->addNode('localhost', 9200);
+    $request = $sherlock->search();
+
+	$request->index('jdbc')
+			->type('jdbc')
+			->query(Sherlock::queryBuilder()
+				->FuzzyLikeThis()
+				->fields( array('description', 'tags', 'name') )
+				->like_text( $query )
+				->min_similarity( 0.6 )
+			);
+
+	$response = $request->execute();
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,12 @@ The library interface is still under flux...this section will be updated once _S
 
 ```
 
+Other types of queries
+----------------------
+
 You can use sherlock with every type of query listed in the elasticsearch docs.
 E.g. if you'd like to use a _fuzzy like this (flt)_ query, you can build your query like this:
+
 	php
 	$sherlock = new Sherlock();
     $sherlock->addNode('localhost', 9200);

--- a/src/Sherlock/Sherlock.php
+++ b/src/Sherlock/Sherlock.php
@@ -126,7 +126,7 @@ class Sherlock
      */
     public static function queryBuilder()
     {
-        Analog::log("Sherlock::query()", Analog::DEBUG);
+        Analog::log(__METHOD__, Analog::DEBUG);
 
         return new \Sherlock\wrappers\QueryWrapper();
     }

--- a/src/Sherlock/Sherlock.php
+++ b/src/Sherlock/Sherlock.php
@@ -137,7 +137,7 @@ class Sherlock
      */
     public static function filterBuilder()
     {
-        Analog::log("Sherlock::filter()", Analog::DEBUG);
+        Analog::log(__METHOD__, Analog::DEBUG);
 
         return new wrappers\FilterWrapper();
     }

--- a/src/Sherlock/components/BaseComponent.php
+++ b/src/Sherlock/components/BaseComponent.php
@@ -54,7 +54,16 @@ abstract class BaseComponent
         if ($name == 'toJSON')
             return $this->toJSON();
 
-        $this->params[$name] = $arguments[0];
+		if ( $this instanceof \Sherlock\components\QueryInterface ) {
+			if( $this->argumentExists( $name ) ) {
+				$this->params[$name] = $arguments[0];
+			} else {
+				throw new \Exception( sprintf( 'You called "%s()" on %s, but that object doesn\'t accept that call.', $name, get_class( $this ) ), 500 );
+			}
+		} else {
+			$this->params[$name] = $arguments[0];
+		}
+
 
         return $this;
     }
@@ -68,6 +77,17 @@ abstract class BaseComponent
     {
         return json_encode($this->toArray());
     }
+
+    /**
+     * Return true or false, depending if this query interface accepts the call or not.
+     * We determine what calls are accepted by looking at the parameter keys defined in
+     * respective component.
+     * @param $call the name of the method called
+     * @return bool
+     */
+    public function argumentExists( $call ) {
+	    return array_key_exists( $call, $this->params );
+   	}
 
     /**
      * Return an associative array representation of this component

--- a/src/Sherlock/components/BaseComponent.php
+++ b/src/Sherlock/components/BaseComponent.php
@@ -58,12 +58,11 @@ abstract class BaseComponent
 			if( $this->argumentExists( $name ) ) {
 				$this->params[$name] = $arguments[0];
 			} else {
-				throw new \Exception( sprintf( 'You called "%s()" on %s, but that object doesn\'t accept that call.', $name, get_class( $this ) ), 500 );
+				throw new \Sherlock\common\exceptions\BadMethodCallException( sprintf( 'You called "%s()" on %s, but that object doesn\'t accept that call.', $name, get_class( $this ) ), 500 );
 			}
 		} else {
 			$this->params[$name] = $arguments[0];
 		}
-
 
         return $this;
     }

--- a/src/Sherlock/components/filters/AndFilter.php
+++ b/src/Sherlock/components/filters/AndFilter.php
@@ -26,9 +26,9 @@ class AndFilter extends \Sherlock\components\BaseComponent implements \Sherlock\
     public function toArray()
     {
         $ret = array (
-  'and' => $this->params["and"],
-  '_cache' => $this->params["_cache"],
-);
+			'and' => $this->params["and"],
+			'_cache' => $this->params["_cache"],
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/filters/Term.php
+++ b/src/Sherlock/components/filters/Term.php
@@ -28,12 +28,12 @@ class Term extends \Sherlock\components\BaseComponent implements \Sherlock\compo
     public function toArray()
     {
         $ret = array (
-  'term' =>
-  array (
-    $this->params["field"] => $this->params["term"],
-    '_cache' => $this->params["_cache"],
-  ),
-);
+			'term' =>
+			array (
+				$this->params["field"] => $this->params["term"],
+			    '_cache' => $this->params["_cache"],
+			),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Bool.php
+++ b/src/Sherlock/components/queries/Bool.php
@@ -14,7 +14,6 @@ use Sherlock\components;
  * @method \Sherlock\components\queries\Bool minimum_number_should_match() minimum_number_should_match(\int $value) Default: 2
  * @method \Sherlock\components\queries\Bool boost() boost(\float $value) Default: 1.0
  * @method \Sherlock\components\queries\Bool disable_coord() disable_coord(\int $value) Default: 1
-
  */
 class Bool extends \Sherlock\components\BaseComponent implements \Sherlock\components\QueryInterface
 {
@@ -33,8 +32,6 @@ class Bool extends \Sherlock\components\BaseComponent implements \Sherlock\compo
     public function must($value)
     {
         $args = func_get_args();
-        if (count($args) == 1)
-            $args = $args[0];
 
         foreach ($args as $arg) {
             if ($arg instanceof \Sherlock\components\QueryInterface)
@@ -47,8 +44,6 @@ class Bool extends \Sherlock\components\BaseComponent implements \Sherlock\compo
     public function must_not($value)
     {
         $args = func_get_args();
-        if (count($args) == 1)
-            $args = $args[0];
 
         foreach ($args as $arg) {
             if ($arg instanceof \Sherlock\components\QueryInterface)
@@ -61,8 +56,6 @@ class Bool extends \Sherlock\components\BaseComponent implements \Sherlock\compo
     public function should($value)
     {
         $args = func_get_args();
-        if (count($args) == 1)
-            $args = $args[0];
 
         foreach ($args as $arg) {
             if ($arg instanceof \Sherlock\components\QueryInterface)
@@ -78,16 +71,16 @@ class Bool extends \Sherlock\components\BaseComponent implements \Sherlock\compo
     public function toArray()
     {
         $ret = array (
-  'bool' =>
-  array (
-    'must' => $this->params["must"],
-    'must_not' => $this->params["must_not"],
-    'should' => $this->params["should"],
-    'minimum_number_should_match' => $this->params["minimum_number_should_match"],
-    'boost' => $this->params["boost"],
-    'disable_coord' => $this->params["disable_coord"],
-  ),
-);
+            'bool' =>
+            array (
+                'must' => $this->params["must"],
+                'must_not' => $this->params["must_not"],
+                'should' => $this->params["should"],
+                'minimum_number_should_match' => $this->params["minimum_number_should_match"],
+                'boost' => $this->params["boost"],
+                'disable_coord' => $this->params["disable_coord"],
+            ),
+        );
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Boosting.php
+++ b/src/Sherlock/components/queries/Boosting.php
@@ -20,6 +20,8 @@ class Boosting extends \Sherlock\components\BaseComponent implements \Sherlock\c
 {
     public function __construct($hashMap = null)
     {
+        $this->params['negative'] = null;
+        $this->params['positive'] = null;
         $this->params['negative_boost'] = 0.2;
 
         parent::__construct($hashMap);

--- a/src/Sherlock/components/queries/ConstantScore.php
+++ b/src/Sherlock/components/queries/ConstantScore.php
@@ -19,6 +19,7 @@ class ConstantScore extends \Sherlock\components\BaseComponent implements \Sherl
 {
     public function __construct($hashMap = null)
     {
+        $this->params['filter'] = null;
         $this->params['boost'] = 1.2;
 
         parent::__construct($hashMap);
@@ -27,12 +28,12 @@ class ConstantScore extends \Sherlock\components\BaseComponent implements \Sherl
     public function toArray()
     {
         $ret = array (
-  'constant_score' =>
-  array (
-    'filter' => $this->params["filter"]->toArray(),
-    'boost' => $this->params["boost"],
-  ),
-);
+				  'constant_score' =>
+				  array (
+					'filter' => $this->params["filter"]->toArray(),
+					'boost' => $this->params["boost"],
+				  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/CustomBoostFactor.php
+++ b/src/Sherlock/components/queries/CustomBoostFactor.php
@@ -19,6 +19,7 @@ class CustomBoostFactor extends \Sherlock\components\BaseComponent implements \S
 {
     public function __construct($hashMap = null)
     {
+        $this->params['query'] = null;
         $this->params['boost_factor'] = 3;
 
         parent::__construct($hashMap);
@@ -27,12 +28,12 @@ class CustomBoostFactor extends \Sherlock\components\BaseComponent implements \S
     public function toArray()
     {
         $ret = array (
-  'custom_boost_factor' =>
-  array (
-    'query' => $this->params["query"]->toArray(),
-    'boost_factor' => $this->params["boost_factor"],
-  ),
-);
+  		'custom_boost_factor' =>
+			 array (
+			    'query' => $this->params["query"]->toArray(),
+			    'boost_factor' => $this->params["boost_factor"],
+			  ),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/CustomFiltersScore.php
+++ b/src/Sherlock/components/queries/CustomFiltersScore.php
@@ -20,6 +20,8 @@ class CustomFiltersScore extends \Sherlock\components\BaseComponent implements \
 {
     public function __construct($hashMap = null)
     {
+        $this->params['query'] = null;
+        $this->params['filters'] = array();
         $this->params['score_mode'] = "first";
         $this->params['max_boost'] = 10;
 
@@ -56,14 +58,14 @@ class CustomFiltersScore extends \Sherlock\components\BaseComponent implements \
         }
 
         $ret = array (
-  'custom_filters_score' =>
-  array (
-    'query' => $this->params["query"]->toArray(),
-    'filters' => $filters,
-    'score_mode' => $this->params["score_mode"],
-    'max_boost' => $this->params["max_boost"],
-  ),
-);
+			'custom_filters_score' =>
+			array (
+			    'query' => $this->params["query"]->toArray(),
+			    'filters' => $filters,
+			    'score_mode' => $this->params["score_mode"],
+			    'max_boost' => $this->params["max_boost"],
+			),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/CustomScore.php
+++ b/src/Sherlock/components/queries/CustomScore.php
@@ -21,6 +21,9 @@ class CustomScore extends \Sherlock\components\BaseComponent implements \Sherloc
 {
     public function __construct($hashMap = null)
     {
+        $this->params['query'] = array();
+        $this->params['params'] = null;
+        $this->params['script'] = null;
         $this->params['lang'] = "mvel";
 
         parent::__construct($hashMap);
@@ -29,14 +32,14 @@ class CustomScore extends \Sherlock\components\BaseComponent implements \Sherloc
     public function toArray()
     {
         $ret = array (
-  'custom_score' =>
-  array (
-    'query' => $this->params["query"]->toArray(),
-    'params' => $this->params["params"],
-    'script' => $this->params["script"],
-    'lang' => $this->params["lang"],
-  ),
-);
+  			'custom_score' =>
+				 array (
+					'query' => $this->params["query"]->toArray(),
+					'params' => $this->params["params"],
+					'script' => $this->params["script"],
+					'lang' => $this->params["lang"],
+  				),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/DisMax.php
+++ b/src/Sherlock/components/queries/DisMax.php
@@ -18,6 +18,7 @@ class DisMax extends \Sherlock\components\BaseComponent implements \Sherlock\com
 {
     public function __construct($hashMap = null)
     {
+        $this->params['queries'] = null;
         $this->params['tie_breaker'] = 0.5;
         $this->params['boost'] = 2;
 
@@ -49,13 +50,13 @@ class DisMax extends \Sherlock\components\BaseComponent implements \Sherlock\com
     public function toArray()
     {
         $ret = array (
-  'dis_max' =>
-  array (
-    'tie_breaker' => $this->params["tie_breaker"],
-    'boost' => $this->params["boost"],
-    'queries' => $this->params['queries'],
-  ),
-);
+  			'dis_max' =>
+				array (
+					'tie_breaker' => $this->params["tie_breaker"],
+					'boost' => $this->params["boost"],
+					'queries' => $this->params['queries'],
+  				),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Field.php
+++ b/src/Sherlock/components/queries/Field.php
@@ -33,6 +33,8 @@ class Field extends \Sherlock\components\BaseComponent implements \Sherlock\comp
 {
     public function __construct($hashMap = null)
     {
+        $this->params['field'] = null;
+        $this->params['query'] = null;
         $this->params['boost'] = 2.0;
         $this->params['enable_position_increments'] = 1;
         $this->params['default_operator'] = "AND";

--- a/src/Sherlock/components/queries/FilteredQuery.php
+++ b/src/Sherlock/components/queries/FilteredQuery.php
@@ -17,8 +17,10 @@ use Sherlock\components;
  */
 class FilteredQuery extends \Sherlock\components\BaseComponent implements \Sherlock\components\QueryInterface
 {
-    public function __construct($hashMap = null)
+	public function __construct($hashMap = null)
     {
+		$this->params['query'] = null;
+		$this->params['filter'] = null;
 
         parent::__construct($hashMap);
     }
@@ -26,12 +28,12 @@ class FilteredQuery extends \Sherlock\components\BaseComponent implements \Sherl
     public function toArray()
     {
         $ret = array (
-  'filtered' =>
-  array (
-    'query' => $this->params["query"]->toArray(),
-    'filter' => $this->params["filter"],
-  ),
-);
+  			'filtered' =>
+				array (
+				    'query' => $this->params["query"]->toArray(),
+				    'filter' => $this->params["filter"],
+				),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Fuzzy.php
+++ b/src/Sherlock/components/queries/Fuzzy.php
@@ -21,33 +21,35 @@ use Sherlock\components;
  */
 class Fuzzy extends \Sherlock\components\BaseComponent implements \Sherlock\components\QueryInterface
 {
+	protected $_allowed;
+
     public function __construct($hashMap = null)
     {
+        $this->params['field'] = null;	// Setting as default for argumentExists check
+        $this->params['value'] = null;	// idem
         $this->params['boost'] = 1.0;
         $this->params['min_similarity'] = 0.2;
         $this->params['prefix_length'] = 0;
         $this->params['max_expansions'] = 10;
-
         parent::__construct($hashMap);
     }
 
     public function toArray()
     {
         $ret = array (
-  'fuzzy' =>
-  array (
-    $this->params["field"] =>
-    array (
-      'value' => $this->params["value"],
-      'boost' => $this->params["boost"],
-      'min_similarity' => $this->params["min_similarity"],
-      'prefix_length' => $this->params["prefix_length"],
-      'max_expansions' => $this->params["max_expansions"],
-    ),
-  ),
-);
-
-        return $ret;
+		'fuzzy' =>
+		array (
+			$this->params["field"] =>
+				array (
+					  'value' => $this->params["value"],
+					  'boost' => $this->params["boost"],
+					  'min_similarity' => $this->params["min_similarity"],
+					  'prefix_length' => $this->params["prefix_length"],
+					  'max_expansions' => $this->params["max_expansions"],
+    			),
+			),
+		);
+    	return $ret;
     }
 
 }

--- a/src/Sherlock/components/queries/FuzzyLikeThis.php
+++ b/src/Sherlock/components/queries/FuzzyLikeThis.php
@@ -25,6 +25,8 @@ class FuzzyLikeThis extends \Sherlock\components\BaseComponent implements \Sherl
 {
     public function __construct($hashMap = null)
     {
+        $this->params['fields'] = null;
+        $this->params['like_text'] = null;
         $this->params['max_query_terms'] = 10;
         $this->params['min_similarity'] = 0.5;
         $this->params['prefix_length'] = 3;
@@ -38,18 +40,18 @@ class FuzzyLikeThis extends \Sherlock\components\BaseComponent implements \Sherl
     public function toArray()
     {
         $ret = array (
-  'fuzzy_like_this' =>
-  array (
-    'fields' => $this->params["fields"],
-    'like_text' => $this->params["like_text"],
-    'max_query_terms' => $this->params["max_query_terms"],
-    'min_similarity' => $this->params["min_similarity"],
-    'prefix_length' => $this->params["prefix_length"],
-    'boost' => $this->params["boost"],
-    'analyzer' => $this->params["analyzer"],
-    'ignore_tf' => $this->params["ignore_tf"],
-  ),
-);
+			'fuzzy_like_this' =>
+				  array (
+					'fields' => $this->params["fields"],
+					'like_text' => $this->params["like_text"],
+					'max_query_terms' => $this->params["max_query_terms"],
+					'min_similarity' => $this->params["min_similarity"],
+					'prefix_length' => $this->params["prefix_length"],
+					'boost' => $this->params["boost"],
+					'analyzer' => $this->params["analyzer"],
+					'ignore_tf' => $this->params["ignore_tf"],
+				  ),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/FuzzyLikeThisField.php
+++ b/src/Sherlock/components/queries/FuzzyLikeThisField.php
@@ -25,6 +25,8 @@ class FuzzyLikeThisField extends \Sherlock\components\BaseComponent implements \
 {
     public function __construct($hashMap = null)
     {
+        $this->params['field'] = null;
+        $this->params['like_text'] = null;
         $this->params['max_query_terms'] = 10;
         $this->params['min_similarity'] = 0.5;
         $this->params['prefix_length'] = 3;

--- a/src/Sherlock/components/queries/HasChild.php
+++ b/src/Sherlock/components/queries/HasChild.php
@@ -20,6 +20,8 @@ class HasChild extends \Sherlock\components\BaseComponent implements \Sherlock\c
 {
     public function __construct($hashMap = null)
     {
+        $this->params['type'] = null;
+        $this->params['query'] = null;
         $this->params['score_type'] = "sum";
 
         parent::__construct($hashMap);
@@ -28,13 +30,13 @@ class HasChild extends \Sherlock\components\BaseComponent implements \Sherlock\c
     public function toArray()
     {
         $ret = array (
-  'has_child' =>
-  array (
-    'type' => $this->params["type"],
-    'score_type' => $this->params["score_type"],
-    'query' => $this->params["query"]->toArray(),
-  ),
-);
+			'has_child' =>
+				array (
+					'type' => $this->params["type"],
+					'score_type' => $this->params["score_type"],
+					'query' => $this->params["query"]->toArray(),
+				),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/HasParent.php
+++ b/src/Sherlock/components/queries/HasParent.php
@@ -20,6 +20,8 @@ class HasParent extends \Sherlock\components\BaseComponent implements \Sherlock\
 {
     public function __construct($hashMap = null)
     {
+        $this->params['parent_type'] = null;
+        $this->params['query'] = null;
         $this->params['score_type'] = "score";
 
         parent::__construct($hashMap);
@@ -28,13 +30,13 @@ class HasParent extends \Sherlock\components\BaseComponent implements \Sherlock\
     public function toArray()
     {
         $ret = array (
-  'has_parent' =>
-  array (
-    'parent_type' => $this->params["parent_type"],
-    'score_type' => $this->params["score_type"],
-    'query' => $this->params["query"]->toArray(),
-  ),
-);
+				  'has_parent' =>
+				  array (
+					'parent_type' => $this->params["parent_type"],
+					'score_type' => $this->params["score_type"],
+					'query' => $this->params["query"]->toArray(),
+				  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Ids.php
+++ b/src/Sherlock/components/queries/Ids.php
@@ -19,6 +19,8 @@ class Ids extends \Sherlock\components\BaseComponent implements \Sherlock\compon
 {
     public function __construct($hashMap = null)
     {
+		$this->params['type'] = null;
+		$this->params['values'] = null;
 
         parent::__construct($hashMap);
     }
@@ -26,12 +28,12 @@ class Ids extends \Sherlock\components\BaseComponent implements \Sherlock\compon
     public function toArray()
     {
         $ret = array (
-  'ids' =>
-  array (
-    'type' => $this->params["type"],
-    'values' => $this->params["values"],
-  ),
-);
+			'ids' =>
+				array (
+				    'type' => $this->params["type"],
+				    'values' => $this->params["values"],
+				),
+		);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Indices.php
+++ b/src/Sherlock/components/queries/Indices.php
@@ -18,7 +18,10 @@ class Indices extends \Sherlock\components\BaseComponent implements \Sherlock\co
 {
     public function __construct($hashMap = null)
     {
-
+		$this->params['query'] = null;
+		$this->params['no_match_query'] = null;
+		$this->params['indices'] = array();
+		
         parent::__construct($hashMap);
     }
 
@@ -46,13 +49,13 @@ class Indices extends \Sherlock\components\BaseComponent implements \Sherlock\co
     public function toArray()
     {
         $ret = array (
-  'indices' =>
-  array (
-    'indices' => $this->params["indices"],
-    'query' => $this->params["query"]->toArray(),
-    'no_match_query' => $this->params["no_match_query"]->toArray(),
-  ),
-);
+				  'indices' =>
+				  array (
+					'indices' => $this->params["indices"],
+					'query' => $this->params["query"]->toArray(),
+					'no_match_query' => $this->params["no_match_query"]->toArray(),
+				  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Match.php
+++ b/src/Sherlock/components/queries/Match.php
@@ -29,6 +29,8 @@ class Match extends \Sherlock\components\BaseComponent implements \Sherlock\comp
 {
     public function __construct($hashMap = null)
     {
+        $this->params['field'] = array();
+        $this->params['query'] = null;
         $this->params['boost'] = 1.0;
         $this->params['operator'] = 'and';
         $this->params['analyzer'] = 'default';

--- a/src/Sherlock/components/queries/MatchAll.php
+++ b/src/Sherlock/components/queries/MatchAll.php
@@ -26,11 +26,11 @@ class MatchAll extends \Sherlock\components\BaseComponent implements \Sherlock\c
     public function toArray()
     {
         $ret = array (
-  'match_all' =>
-  array (
-    'boost' => $this->params["boost"],
-  ),
-);
+				  'match_all' =>
+				  array (
+					'boost' => $this->params["boost"],
+				  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/MoreLikeThis.php
+++ b/src/Sherlock/components/queries/MoreLikeThis.php
@@ -29,6 +29,8 @@ class MoreLikeThis extends \Sherlock\components\BaseComponent implements \Sherlo
 {
     public function __construct($hashMap = null)
     {
+        $this->params['fields'] = null;
+        $this->params['like_text'] = null;
         $this->params['min_term_freq'] = 2;
         $this->params['max_query_terms'] = 25;
         $this->params['percent_terms_to_match'] = 0.3;
@@ -46,22 +48,22 @@ class MoreLikeThis extends \Sherlock\components\BaseComponent implements \Sherlo
     public function toArray()
     {
         $ret = array (
-  'more_like_this' =>
-  array (
-    'fields' => $this->params["fields"],
-    'like_text' => $this->params["like_text"],
-    'min_term_freq' => $this->params["min_term_freq"],
-    'max_query_terms' => $this->params["max_query_terms"],
-    'percent_terms_to_match' => $this->params["percent_terms_to_match"],
-    'stop_words' => $this->params["stop_words"],
-    'min_doc_freq' => $this->params["min_doc_freq"],
-    'max_doc_freq' => $this->params["max_doc_freq"],
-    'min_word_len' => $this->params["min_word_len"],
-    'max_word_len' => $this->params["max_word_len"],
-    'boost_terms' => $this->params["boost_terms"],
-    'boost' => $this->params["boost"],
-  ),
-);
+				  'more_like_this' =>
+				  array (
+					'fields' => $this->params["fields"],
+					'like_text' => $this->params["like_text"],
+					'min_term_freq' => $this->params["min_term_freq"],
+					'max_query_terms' => $this->params["max_query_terms"],
+					'percent_terms_to_match' => $this->params["percent_terms_to_match"],
+					'stop_words' => $this->params["stop_words"],
+					'min_doc_freq' => $this->params["min_doc_freq"],
+					'max_doc_freq' => $this->params["max_doc_freq"],
+					'min_word_len' => $this->params["min_word_len"],
+					'max_word_len' => $this->params["max_word_len"],
+					'boost_terms' => $this->params["boost_terms"],
+					'boost' => $this->params["boost"],
+				  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/MoreLikeThisField.php
+++ b/src/Sherlock/components/queries/MoreLikeThisField.php
@@ -29,6 +29,8 @@ class MoreLikeThisField extends \Sherlock\components\BaseComponent implements \S
 {
     public function __construct($hashMap = null)
     {
+        $this->params['field'] = null;
+        $this->params['like_text'] = null;
         $this->params['min_term_freq'] = 2;
         $this->params['max_query_terms'] = 25;
         $this->params['percent_terms_to_match'] = 0.3;
@@ -46,23 +48,23 @@ class MoreLikeThisField extends \Sherlock\components\BaseComponent implements \S
     public function toArray()
     {
         $ret = array (
-  'more_like_this_field' =>
-  array (
-    $this->params["field"] =>
-    array (
-      'like_text' => $this->params["like_text"],
-      'min_term_freq' => $this->params["min_term_freq"],
-      'max_query_terms' => $this->params["max_query_terms"],
-      'percent_terms_to_match' => $this->params["percent_terms_to_match"],
-      'stop_words' => $this->params["stop_words"],
-      'min_doc_freq' => $this->params["min_doc_freq"],
-      'max_doc_freq' => $this->params["max_doc_freq"],
-      'min_word_len' => $this->params["min_word_len"],
-      'max_word_len' => $this->params["max_word_len"],
-      'boost_terms' => $this->params["boost_terms"],
-      'boost' => $this->params["boost"],
-    ),
-  ),
+				  'more_like_this_field' =>
+				  array (
+					$this->params["field"] =>
+					array (
+					  'like_text' => $this->params["like_text"],
+					  'min_term_freq' => $this->params["min_term_freq"],
+					  'max_query_terms' => $this->params["max_query_terms"],
+					  'percent_terms_to_match' => $this->params["percent_terms_to_match"],
+					  'stop_words' => $this->params["stop_words"],
+					  'min_doc_freq' => $this->params["min_doc_freq"],
+					  'max_doc_freq' => $this->params["max_doc_freq"],
+					  'min_word_len' => $this->params["min_word_len"],
+					  'max_word_len' => $this->params["max_word_len"],
+					  'boost_terms' => $this->params["boost_terms"],
+					  'boost' => $this->params["boost"],
+					),
+				  ),
 );
 
         return $ret;

--- a/src/Sherlock/components/queries/Nested.php
+++ b/src/Sherlock/components/queries/Nested.php
@@ -20,6 +20,8 @@ class Nested extends \Sherlock\components\BaseComponent implements \Sherlock\com
 {
     public function __construct($hashMap = null)
     {
+        $this->params['path'] = null;
+        $this->params['query'] = null;
         $this->params['score_mode'] = "avg";
 
         parent::__construct($hashMap);
@@ -28,13 +30,13 @@ class Nested extends \Sherlock\components\BaseComponent implements \Sherlock\com
     public function toArray()
     {
         $ret = array (
-  'nested' =>
-  array (
-    'path' => $this->params["path"],
-    'score_mode' => $this->params["score_mode"],
-    'query' => $this->params["query"]->toArray(),
-  ),
-);
+				'nested' =>
+						array (
+							'path' => $this->params["path"],
+							'score_mode' => $this->params["score_mode"],
+							'query' => $this->params["query"]->toArray(),
+						  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Prefix.php
+++ b/src/Sherlock/components/queries/Prefix.php
@@ -23,6 +23,8 @@ class Prefix extends \Sherlock\components\BaseComponent implements \Sherlock\com
 {
     public function __construct($hashMap = null)
     {
+        $this->params['field'] = null;
+        $this->params['value'] = null;
         $this->params['boost'] = 2.0;
         $this->params['analyzer'] = "default";
         $this->params['slop'] = 3;

--- a/src/Sherlock/components/queries/QueryString.php
+++ b/src/Sherlock/components/queries/QueryString.php
@@ -34,6 +34,7 @@ class QueryString extends \Sherlock\components\BaseComponent implements \Sherloc
 {
     public function __construct($hashMap = null)
     {
+        $this->params['query'] = null;
         $this->params['default_field'] = "_all";
         $this->params['boost'] = 2.0;
         $this->params['enable_position_increments'] = 1;

--- a/src/Sherlock/components/queries/QueryStringMultiField.php
+++ b/src/Sherlock/components/queries/QueryStringMultiField.php
@@ -36,6 +36,8 @@ class QueryStringMultiField extends \Sherlock\components\BaseComponent implement
 {
     public function __construct($hashMap = null)
     {
+        $this->params['query'] = null;
+        $this->params['fields'] = null;
         $this->params['boost'] = 2.0;
         $this->params['enable_position_increments'] = true;
         $this->params['default_operator'] = "OR";
@@ -76,7 +78,6 @@ class QueryStringMultiField extends \Sherlock\components\BaseComponent implement
                         'phrase_slop' => $this->params["phrase_slop"],
                         'analyze_wildcard' => $this->params["analyze_wildcard"],
                         'auto_generate_phrase_queries' => $this->params["auto_generate_phrase_queries"],
-
                         'quote_analyzer' => $this->params["quote_analyzer"],
                         'quote_field_suffix' => $this->params["quote_field_suffix"],
                         'use_dis_max' => $this->params["use_dis_max"],

--- a/src/Sherlock/components/queries/Range.php
+++ b/src/Sherlock/components/queries/Range.php
@@ -23,6 +23,9 @@ class Range extends \Sherlock\components\BaseComponent implements \Sherlock\comp
 {
     public function __construct($hashMap = null)
     {
+        $this->params['field'] = null;
+        $this->params['from'] = 0;
+        $this->params['to'] = 10;
         $this->params['include_lower'] = true;
         $this->params['include_upper'] = true;
         $this->params['boost'] = 1.0;

--- a/src/Sherlock/components/queries/Term.php
+++ b/src/Sherlock/components/queries/Term.php
@@ -19,21 +19,28 @@ class Term extends \Sherlock\components\BaseComponent implements \Sherlock\compo
 {
     public function __construct($hashMap = null)
     {
-
+		$this->params['value'] = null;
+		$this->params['term'] = null;
+		$this->params['field'] = null;
+		$this->params['boost'] = 1.0;
         parent::__construct($hashMap);
     }
 
+	/**
+	 * The term query accepts both "value" and "term" keywords for the query term
+	 */
     public function toArray()
     {
         $ret = array (
-  'term' =>
-  array (
-    $this->params["field"] =>
-    array (
-      'value' => $this->params["term"],
-    ),
-  ),
-);
+				  'term' =>
+				  		array (
+							$this->params["field"] =>
+								array (
+								  'value' => !empty( $this->params['term'] ) ? $this->params['term'] : $this->params['value'],
+								  'boost' => $this->params['boost']
+								),
+						  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Terms.php
+++ b/src/Sherlock/components/queries/Terms.php
@@ -19,6 +19,8 @@ class Terms extends \Sherlock\components\BaseComponent implements \Sherlock\comp
 {
     public function __construct($hashMap = null)
     {
+        $this->params['field'] = null;
+        $this->params['terms'] = null;
         $this->params['minimum_match'] = 2;
 
         parent::__construct($hashMap);
@@ -49,13 +51,12 @@ class Terms extends \Sherlock\components\BaseComponent implements \Sherlock\comp
     public function toArray()
     {
         $ret = array (
-  'terms' =>
-  array (
-      $this->params["field"] => $this->params["terms"],
-      'minimum_match' => $this->params["minimum_match"],
-
-  ),
-);
+			'terms' =>
+				array (
+					$this->params["field"] => $this->params["terms"],
+					'minimum_match' => $this->params["minimum_match"],
+				),
+			);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/TopChildren.php
+++ b/src/Sherlock/components/queries/TopChildren.php
@@ -22,6 +22,8 @@ class TopChildren extends \Sherlock\components\BaseComponent implements \Sherloc
 {
     public function __construct($hashMap = null)
     {
+        $this->params['type'] = null;
+        $this->params['query'] = null;
         $this->params['score'] = "max";
         $this->params['factor'] = 5;
         $this->params['incremental_factor'] = 5;
@@ -32,15 +34,15 @@ class TopChildren extends \Sherlock\components\BaseComponent implements \Sherloc
     public function toArray()
     {
         $ret = array (
-  'top_children' =>
-  array (
-    'type' => $this->params["type"],
-    'query' => $this->params["query"]->toArray(),
-    'score' => $this->params["score"],
-    'factor' => $this->params["factor"],
-    'incremental_factor' => $this->params["incremental_factor"],
-  ),
-);
+				  'top_children' =>
+				  array (
+					'type' => $this->params["type"],
+					'query' => $this->params["query"]->toArray(),
+					'score' => $this->params["score"],
+					'factor' => $this->params["factor"],
+					'incremental_factor' => $this->params["incremental_factor"],
+				  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/components/queries/Wildcard.php
+++ b/src/Sherlock/components/queries/Wildcard.php
@@ -20,6 +20,8 @@ class Wildcard extends \Sherlock\components\BaseComponent implements \Sherlock\c
 {
     public function __construct($hashMap = null)
     {
+        $this->params['value'] = null;
+        $this->params['field'] = null;
         $this->params['boost'] = 1.0;
 
         parent::__construct($hashMap);
@@ -28,15 +30,15 @@ class Wildcard extends \Sherlock\components\BaseComponent implements \Sherlock\c
     public function toArray()
     {
         $ret = array (
-  'wildcard' =>
-  array (
-    $this->params["field"] =>
-    array (
-      'value' => $this->params["value"],
-      'boost' => $this->params["boost"],
-    ),
-  ),
-);
+				  'wildcard' =>
+				  array (
+					$this->params["field"] =>
+					array (
+					  'value' => $this->params["value"],
+					  'boost' => $this->params["boost"],
+					),
+				  ),
+				);
 
         return $ret;
     }

--- a/src/Sherlock/requests/DeleteDocumentRequest.php
+++ b/src/Sherlock/requests/DeleteDocumentRequest.php
@@ -26,7 +26,8 @@ class DeleteDocumentRequest extends Request
     public function __construct($dispatcher)
     {
         if (!isset($dispatcher))
-            throw new \Sherlock\common\exceptions\BadMethodCallException("Dispatcher argument required for IndexRequest");
+            throw new \Sherlock\common\exceptions\BadMethodCallException(
+                "Dispatcher argument required for " . __CLASS__);
 
         $this->dispatcher = $dispatcher;
 
@@ -79,6 +80,21 @@ class DeleteDocumentRequest extends Request
         }
 
         return $this;
+    }
+
+    /**
+     * Retrieve the BatchCommand array, for
+     * instance for usage in the documents() method.
+     * @return object BatchCommand object of Commands
+     */
+    public function retrieveBatch()
+    {
+        if (!$this->batch || !$this->batch instanceof BatchCommand) {
+            Analog::error("There is no BatchCommand to be retrieved");
+            throw new exceptions\RuntimeException("There is no BatchCommand to be retrieved");
+        }
+
+        return $this->batch;
     }
 
     /**

--- a/src/Sherlock/requests/SearchRequest.php
+++ b/src/Sherlock/requests/SearchRequest.php
@@ -254,6 +254,10 @@ class SearchRequest extends Request
     {
         $finalQuery = array();
 
+		if(isset($this->params['query']) && $this->params['query'] instanceof queries\Raw) {
+			return $this->params['query']->toJSON();
+		}
+
         if (isset($this->params['query']) && $this->params['query'] instanceof components\QueryInterface) {
             $finalQuery['query'] = $this->params['query']->toArray();
         }


### PR DESCRIPTION
Hey, in Bool.php you strip QueryInterface Objects of their object and only leave their params array when only one object is passed to the must(), should() or should_not() methods.
See https://github.com/polyfractal/sherlock/blob/master/src/Sherlock/components/queries/Bool.php#L71

Sorry, I don't know how to specify just a single commit but you should only need to apply the latest. Maybe you'll simply want to apply this manually.

Also, regarding the ServiceProvider for Silex, I did this to have sort of a singleton pattern and to be able to configure it centrally in a silex project. Maybe you feel this isn't a good idea to add random adapters to your source base, just let me know and I'll keep it inside the contrib folders of my silex projects.
