### PR TITLE
Nested param

### DIFF
--- a/src/Sherlock/components/facets/Terms.php
+++ b/src/Sherlock/components/facets/Terms.php
@@ -48,6 +48,7 @@ class Terms extends components\BaseComponent implements components\FacetInterfac
         $this->params['params']       = null;
         $this->params['lang']         = null;
         $this->params['facet_filter'] = null;
+        $this->params['nested']       = null;
 
         parent::__construct($hashMap);
     }
@@ -119,7 +120,8 @@ class Terms extends components\BaseComponent implements components\FacetInterfac
                     "params"       => $this->params['params'],
                     "lang"         => $this->params['lang']
                 ),
-                "facet_filter" => $this->params['facet_filter']
+                "facet_filter"  => $this->params['facet_filter'],
+                "nested"    => $this->params['nested']
             )
         );
 


### PR DESCRIPTION
I implemented this because this param is necessary when you have different Facets types ( nested and string for example) and works fine to me!

How to use:
        $facetcolor = Sherlock::facetBuilder()->Terms()
                    ->fields("options.colors")
                    ->nested("options")
                    ->facetname("Colors");

The Output:
        "Color": {
            "terms":{
                "field":"options.color"
            },
                "nested": "options"
        }
