### PR TITLE
Added field() method for geofilters; added class to sort by GeoDistance

### DIFF
--- a/src/Sherlock/components/filters/GeoBoundingBox.php
+++ b/src/Sherlock/components/filters/GeoBoundingBox.php
@@ -16,6 +16,7 @@ use Sherlock\components;
  * @method \Sherlock\components\filters\GeoBoundingBox bottom_right_lat() bottom_right_lat(\float $value)
  * @method \Sherlock\components\filters\GeoBoundingBox bottom_right_lon() bottom_right_lon(\float $value)
  * @method \Sherlock\components\filters\GeoBoundingBox type() type(\string $value) Default: "memory"
+ * @method \Sherlock\components\filters\GeoBoundingBox field() field(\float $value) Default: pin.location
  * @method \Sherlock\components\filters\GeoBoundingBox _cache() _cache(\bool $value) Default: false
 
  */
@@ -25,6 +26,7 @@ class GeoBoundingBox extends \Sherlock\components\BaseComponent implements \Sher
     {
         $this->params['type']   = "memory";
         $this->params['_cache'] = false;
+        $this->params['field'] = 'pin.location';
 
         parent::__construct($hashMap);
     }
@@ -35,7 +37,7 @@ class GeoBoundingBox extends \Sherlock\components\BaseComponent implements \Sher
         $ret = array(
             'geo_bounding_box' =>
             array(
-                'pin.location' =>
+                $this->params["field"] =>
                 array(
                     'top_left'     =>
                     array(

--- a/src/Sherlock/components/filters/GeoDistance.php
+++ b/src/Sherlock/components/filters/GeoDistance.php
@@ -14,6 +14,7 @@ use Sherlock\components;
  * @method \Sherlock\components\filters\GeoDistance distance() distance(\string $value)
  * @method \Sherlock\components\filters\GeoDistance lat() lat(\float $value)
  * @method \Sherlock\components\filters\GeoDistance lon() lon(\float $value)
+ * @method \Sherlock\components\filters\GeoDistance field() field(\float $value) Default: pin.location
  * @method \Sherlock\components\filters\GeoDistance _cache() _cache(\bool $value) Default: false
 
  */
@@ -22,6 +23,7 @@ class GeoDistance extends \Sherlock\components\BaseComponent implements \Sherloc
     public function __construct($hashMap = null)
     {
         $this->params['_cache'] = false;
+        $this->params['field'] = 'pin.location';
 
         parent::__construct($hashMap);
     }
@@ -33,7 +35,7 @@ class GeoDistance extends \Sherlock\components\BaseComponent implements \Sherloc
             'geo_distance' =>
             array(
                 'distance'     => $this->params["distance"],
-                'pin.location' =>
+                $this->params["field"] =>
                 array(
                     'lat' => $this->params["lat"],
                     'lon' => $this->params["lon"],

--- a/src/Sherlock/components/filters/GeoDistanceRange.php
+++ b/src/Sherlock/components/filters/GeoDistanceRange.php
@@ -15,6 +15,7 @@ use Sherlock\components;
  * @method \Sherlock\components\filters\GeoDistanceRange to() to(\string $value)
  * @method \Sherlock\components\filters\GeoDistanceRange lat() lat(\float $value)
  * @method \Sherlock\components\filters\GeoDistanceRange lon() lon(\float $value)
+ * @method \Sherlock\components\filters\GeoDistanceRange field() field(\float $value) Default: pin.location
  * @method \Sherlock\components\filters\GeoDistanceRange _cache() _cache(\bool $value) Default: false
 
  */
@@ -23,6 +24,7 @@ class GeoDistanceRange extends \Sherlock\components\BaseComponent implements \Sh
     public function __construct($hashMap = null)
     {
         $this->params['_cache'] = false;
+        $this->params['field'] = 'pin.location';
 
         parent::__construct($hashMap);
     }
@@ -35,7 +37,7 @@ class GeoDistanceRange extends \Sherlock\components\BaseComponent implements \Sh
             array(
                 'from'         => $this->params["from"],
                 'to'           => $this->params["to"],
-                'pin.location' =>
+                $this->params["field"] =>
                 array(
                     'lat' => $this->params["lat"],
                     'lon' => $this->params["lon"],

--- a/src/Sherlock/components/sorts/GeoDistance.php
+++ b/src/Sherlock/components/sorts/GeoDistance.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * User: Zachary Tong
+ * Date: 3/7/13
+ * Time: 8:12 PM
+ * @package Sherlock\components\sorts
+ */
+
+namespace Sherlock\components\sorts;
+
+use Sherlock\components;
+
+/**
+ * @method \Sherlock\components\sorts\GeoDistance name() name(\string $value)
+ * @method \Sherlock\components\sorts\GeoDistance order() order(\string $value) Default: asc
+ * @method \Sherlock\components\sorts\GeoDistance lat() lat(\float $value) Default: null
+ * @method \Sherlock\components\sorts\GeoDistance lon() lon(\float $value) Default: null
+ * @method \Sherlock\components\sorts\GeoDistance unit() unit(\string $value) Default: km
+ */
+class GeoDistance extends components\BaseComponent implements components\SortInterface
+{
+    public function __construct($hashMap = null)
+    {
+        $this->params['order']           = 'asc';
+        $this->params['unit']            = 'km';
+
+        parent::__construct($hashMap);
+    }
+
+
+    public function toArray()
+    {
+        $ret = array(
+            '_geo_distance' => array(
+                $this->params['name'] => array($this->params['lon'], $this->params['lat']),
+                'order'           => $this->params["order"],
+                'unit' => $this->params["unit"]
+            )
+        );
+
+        return $ret;
+    }
+
+}


### PR DESCRIPTION
Seems that the documentation in elasticsearch regarding pin.location is just a default they used - which doesn't mean that other developers will actually follow that example.
I've added the possibility to change the name of the field containing the geocoordinates with a fallback to pin.location.

There's also a new sorting class to sort by GeoDistance.

I hope this is useful.
