### PR TITLE
added setOptions method to request.

### DIFF
--- a/src/Sherlock/requests/Request.php
+++ b/src/Sherlock/requests/Request.php
@@ -35,6 +35,10 @@ class Request
      */
     protected $batch;
 
+    /**
+     * @var array
+     */
+    protected $options;
 
     /**
      * @param  \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher
@@ -86,6 +90,10 @@ class Request
 
         $rolling = new RollingCurl\RollingCurl();
         $rolling->setHeaders(array('Content-Type: application/json'));
+
+        if ( ! is_null($this->options)) {
+            $rolling->setOptions($this->options);
+        }
 
         $window  = 10;
         $counter = 0;
@@ -169,4 +177,18 @@ class Request
     {
         return new Response($response);
     }
+
+    /**
+     * Set the options that should be set on the cURL request.
+     *
+     * @param  $options
+     * @return \Sherlock\requests\Request
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
 }


### PR DESCRIPTION
The RollingCurl class has a `setOptions` method, however, since that instance is created within the base Request class' `execute` method, there is never an opportunity to set the options. I've added a `setOptions` to Request that will pass them along to the RollingCurl instance.
