### PR TITLE
fix QueryStringMultiField rewrite parameter

### DIFF
--- a/src/Sherlock/components/queries/QueryStringMultiField.php
+++ b/src/Sherlock/components/queries/QueryStringMultiField.php
@@ -48,7 +48,7 @@ class QueryStringMultiField extends \Sherlock\components\BaseComponent implement
         $this->params['phrase_slop']                  = 10;
         $this->params['analyze_wildcard']             = true;
         $this->params['auto_generate_phrase_queries'] = false;
-        $this->params['rewrite']                      = "constant_score_default";
+        $this->params['rewrite']                      = "constant_score_auto";
         $this->params['quote_analyzer']               = "standard";
         $this->params['quote_field_suffix']           = ".unstemmed";
         $this->params['use_dis_max']                  = true;
@@ -81,8 +81,8 @@ class QueryStringMultiField extends \Sherlock\components\BaseComponent implement
                 'quote_field_suffix'           => $this->params["quote_field_suffix"],
                 'use_dis_max'                  => $this->params["use_dis_max"],
                 'tie_breaker'                  => $this->params["tie_breaker"],
+                'rewrite'                      => $this->params["rewrite"],
             ),
-            'rewrite'      => $this->params["rewrite"],
         );
 
         return $ret;

--- a/src/Sherlock/components/sorts/Script.php
+++ b/src/Sherlock/components/sorts/Script.php
@@ -13,6 +13,7 @@ use Sherlock\components;
 /**
  * @method \Sherlock\components\sorts\Script script() script(\string $value)
  * @method \Sherlock\components\sorts\Script type() type(\string $value)
+ * @method \Sherlock\components\sorts\Script params() params(array $value) Default: array()
  * @method \Sherlock\components\sorts\Script order() order(\string $value) Default: asc
  * @method \Sherlock\components\sorts\Script lang() lang(\string $value) Default: mvel
  */
@@ -24,6 +25,7 @@ class Script extends components\BaseComponent implements components\SortInterfac
     {
         $this->params['script'] = null;
         $this->params['type']   = null;
+        $this->params['params'] = array();
         $this->params['order']  = 'asc';
         $this->params['lang']   = 'mvel';
 
@@ -37,6 +39,7 @@ class Script extends components\BaseComponent implements components\SortInterfac
             array(
                 'script' => $this->params["script"],
                 'type'   => $this->params["type"],
+                'params' => $this->params["params"],
                 'order'  => $this->params["order"],
                 'lang'   => $this->params["lang"],
             ),

--- a/src/Sherlock/components/sorts/Script.php
+++ b/src/Sherlock/components/sorts/Script.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * User: Sam Sullivan
+ * Date: 3/5/14
+ * Time: 8:11 PM
+ * @package Sherlock\components\sorts
+ */
+
+namespace Sherlock\components\sorts;
+
+use Sherlock\components;
+
+/**
+ * @method \Sherlock\components\sorts\Script script() script(\string $value)
+ */
+
+class Script extends components\BaseComponent implements components\SortInterface
+{
+
+    public function __construct($hashMap = null)
+    {
+        $this->params['script'] = null;
+
+        parent::__construct($hashMap);
+    }
+
+    public function toArray()
+    {
+        $ret = array(
+            '_script' =>
+            array(
+                'script' => $this->params["script"],
+            ),
+        );
+
+        return $ret;
+    }
+
+}

--- a/src/Sherlock/components/sorts/Script.php
+++ b/src/Sherlock/components/sorts/Script.php
@@ -12,6 +12,9 @@ use Sherlock\components;
 
 /**
  * @method \Sherlock\components\sorts\Script script() script(\string $value)
+ * @method \Sherlock\components\sorts\Script type() type(\string $value)
+ * @method \Sherlock\components\sorts\Script order() order(\string $value) Default: asc
+ * @method \Sherlock\components\sorts\Script lang() lang(\string $value) Default: mvel
  */
 
 class Script extends components\BaseComponent implements components\SortInterface
@@ -20,6 +23,9 @@ class Script extends components\BaseComponent implements components\SortInterfac
     public function __construct($hashMap = null)
     {
         $this->params['script'] = null;
+        $this->params['type']   = null;
+        $this->params['order']  = 'asc';
+        $this->params['lang']   = 'mvel';
 
         parent::__construct($hashMap);
     }
@@ -30,6 +36,9 @@ class Script extends components\BaseComponent implements components\SortInterfac
             '_script' =>
             array(
                 'script' => $this->params["script"],
+                'type'   => $this->params["type"],
+                'order'  => $this->params["order"],
+                'lang'   => $this->params["lang"],
             ),
         );
 

--- a/src/Sherlock/wrappers/SortWrapper.php
+++ b/src/Sherlock/wrappers/SortWrapper.php
@@ -11,6 +11,8 @@ use Sherlock\components\sorts;
 
 /**
  * @method \Sherlock\components\sorts\Field Field() Field()
+ * @method \Sherlock\components\sorts\GeoDistance GeoDistance() GeoDistance()
+ * @method \Sherlock\components\sorts\Script Script() Script()
  */
 class SortWrapper
 {


### PR DESCRIPTION
With the `rewrite` parameter outside of the `query_string` model, I would receive the following error:

```
[_na] query malformed, must start with start_object
```

Moving that parameter into the model fixed the issue.  Also, `constant_score_default` doesn't seem to be a valid value for `rewrite` anymore.  Instead, `constant_score_auto` seems like the default value.

```
When not set, or set to constant_score_auto, defaults to automatically choosing either constant_score_boolean or constant_score_filter based on query characteristics.
```

Source: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-multi-term-rewrite.html
